### PR TITLE
Suffix common prefixes from title sort

### DIFF
--- a/app/src/main/java/com/syncedsynapse/kore2/ui/AlbumListFragment.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/ui/AlbumListFragment.java
@@ -50,6 +50,7 @@ import com.syncedsynapse.kore2.host.HostManager;
 import com.syncedsynapse.kore2.jsonrpc.ApiException;
 import com.syncedsynapse.kore2.jsonrpc.event.MediaSyncEvent;
 import com.syncedsynapse.kore2.provider.MediaContract;
+import com.syncedsynapse.kore2.provider.MediaDatabase;
 import com.syncedsynapse.kore2.service.LibrarySyncService;
 import com.syncedsynapse.kore2.utils.LogUtils;
 import com.syncedsynapse.kore2.utils.UIUtils;
@@ -329,7 +330,7 @@ public class AlbumListFragment extends Fragment
                 MediaContract.Albums.YEAR,
         };
 
-        String SORT = MediaContract.Albums.TITLE + " ASC";
+        String SORT = MediaDatabase.sortCommonTokens(MediaContract.Albums.TITLE) + " ASC";
 
         final int ID = 0;
         final int ALBUMID = 1;

--- a/app/src/main/java/com/syncedsynapse/kore2/ui/ArtistListFragment.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/ui/ArtistListFragment.java
@@ -50,6 +50,7 @@ import com.syncedsynapse.kore2.host.HostManager;
 import com.syncedsynapse.kore2.jsonrpc.ApiException;
 import com.syncedsynapse.kore2.jsonrpc.event.MediaSyncEvent;
 import com.syncedsynapse.kore2.provider.MediaContract;
+import com.syncedsynapse.kore2.provider.MediaDatabase;
 import com.syncedsynapse.kore2.service.LibrarySyncService;
 import com.syncedsynapse.kore2.utils.LogUtils;
 import com.syncedsynapse.kore2.utils.UIUtils;
@@ -295,7 +296,7 @@ public class ArtistListFragment extends Fragment
                 MediaContract.Movies.THUMBNAIL,
         };
 
-        String SORT = MediaContract.Artists.ARTIST + " ASC";
+        String SORT = MediaDatabase.sortCommonTokens(MediaContract.Artists.ARTIST) + " ASC";
 
         final int ID = 0;
         final int ARTISTID = 1;

--- a/app/src/main/java/com/syncedsynapse/kore2/ui/MovieListFragment.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/ui/MovieListFragment.java
@@ -51,6 +51,7 @@ import com.syncedsynapse.kore2.host.HostManager;
 import com.syncedsynapse.kore2.jsonrpc.ApiException;
 import com.syncedsynapse.kore2.jsonrpc.event.MediaSyncEvent;
 import com.syncedsynapse.kore2.provider.MediaContract;
+import com.syncedsynapse.kore2.provider.MediaDatabase;
 import com.syncedsynapse.kore2.service.LibrarySyncService;
 import com.syncedsynapse.kore2.utils.LogUtils;
 import com.syncedsynapse.kore2.utils.UIUtils;
@@ -335,7 +336,7 @@ public class MovieListFragment extends Fragment
                 MediaContract.Movies.TAGLINE,
         };
 
-        String SORT = MediaContract.Movies.TITLE + " ASC";
+        String SORT = MediaDatabase.sortCommonTokens(MediaContract.Movies.TITLE) + " ASC";
 
         final int ID = 0;
         final int MOVIEID = 1;

--- a/app/src/main/java/com/syncedsynapse/kore2/ui/MusicVideoListFragment.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/ui/MusicVideoListFragment.java
@@ -50,6 +50,7 @@ import com.syncedsynapse.kore2.host.HostManager;
 import com.syncedsynapse.kore2.jsonrpc.ApiException;
 import com.syncedsynapse.kore2.jsonrpc.event.MediaSyncEvent;
 import com.syncedsynapse.kore2.provider.MediaContract;
+import com.syncedsynapse.kore2.provider.MediaDatabase;
 import com.syncedsynapse.kore2.service.LibrarySyncService;
 import com.syncedsynapse.kore2.utils.LogUtils;
 import com.syncedsynapse.kore2.utils.UIUtils;
@@ -286,7 +287,7 @@ public class MusicVideoListFragment extends Fragment
                 MediaContract.MusicVideos.GENRES,
         };
 
-        String SORT = MediaContract.MusicVideos.TITLE + " ASC";
+        String SORT = MediaDatabase.sortCommonTokens(MediaContract.MusicVideos.TITLE) + " ASC";
 
         final int ID = 0;
         final int MUSICVIDEOID = 1;

--- a/app/src/main/java/com/syncedsynapse/kore2/ui/TVShowListFragment.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/ui/TVShowListFragment.java
@@ -51,6 +51,7 @@ import com.syncedsynapse.kore2.host.HostManager;
 import com.syncedsynapse.kore2.jsonrpc.ApiException;
 import com.syncedsynapse.kore2.jsonrpc.event.MediaSyncEvent;
 import com.syncedsynapse.kore2.provider.MediaContract;
+import com.syncedsynapse.kore2.provider.MediaDatabase;
 import com.syncedsynapse.kore2.service.LibrarySyncService;
 import com.syncedsynapse.kore2.utils.LogUtils;
 import com.syncedsynapse.kore2.utils.UIUtils;
@@ -329,7 +330,7 @@ public class TVShowListFragment extends Fragment
                 MediaContract.TVShows.WATCHEDEPISODES,
         };
 
-        String SORT = MediaContract.TVShows.TITLE + " ASC";
+        String SORT = MediaDatabase.sortCommonTokens(MediaContract.TVShows.TITLE) + " ASC";
 
         final int ID = 0;
         final int TVSHOWID = 1;


### PR DESCRIPTION
This adjusts the sorting order slightly to be able to ignore common words like "The ", "An ", "A ".

My kodi's seem to just ignore "The " so that's the only one I have enabled, but would be good to pull from host via JSOONAPI  if/when possible.

Thought this might be useful for the moment and might assist with whatever you decide to do with sorting in the future.
