### PR TITLE
Make codec button switch between codec/context if playing/notplaying

### DIFF
--- a/app/src/main/java/com/syncedsynapse/kore2/jsonrpc/method/Input.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/jsonrpc/method/Input.java
@@ -349,6 +349,27 @@ public class Input {
     }
 
     /**
+     * Open context menu
+     */
+    public static final class ContextMenu extends ApiMethod<String> {
+        public final static String METHOD_NAME = "Input.ContextMenu";
+        /**
+         * Open context menu
+         */
+        public ContextMenu() {
+            super();
+        }
+
+        @Override
+        public String getMethodName() { return METHOD_NAME; }
+
+        @Override
+        public String resultFromJson(ObjectNode jsonObject) throws ApiException {
+            return jsonObject.get(RESULT_NODE).textValue();
+        }
+    }
+
+    /**
      * Select in GUI
      */
     public static final class Select extends ApiMethod<String> {

--- a/app/src/main/java/com/syncedsynapse/kore2/ui/RemoteFragment.java
+++ b/app/src/main/java/com/syncedsynapse/kore2/ui/RemoteFragment.java
@@ -142,7 +142,7 @@ public class RemoteFragment extends Fragment
         setupNoRepeatButton(backButton, new Input.Back());
         setupNoRepeatButton(infoButton, new Input.ExecuteAction(Input.ExecuteAction.INFO));
         setupNoRepeatButton(osdButton, new Input.ExecuteAction(Input.ExecuteAction.OSD));
-        setupNoRepeatButton(codecInfoButton, new Input.ExecuteAction(Input.ExecuteAction.CODECINFO));
+        setupContextualNoRepeatButton(codecInfoButton, new Input.ExecuteAction(Input.ExecuteAction.CODECINFO), new Input.ContextMenu());
 
 //        // Padd main content view to account for bottom system bar
 //        UIUtils.setPaddingForSystemBars(getActivity(), root, false, false, true);
@@ -204,6 +204,20 @@ public class RemoteFragment extends Fragment
                     }
                 }, buttonInAnim, buttonOutAnim));
     }
+
+    private void setupContextualNoRepeatButton(View button, final ApiMethod<String> actionPlaying, final ApiMethod<String> actionNotPlaying) {
+        button.setOnTouchListener(new RepeatListener(-1, -1,
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (isNowPlaying())
+                            actionPlaying.execute(hostManager.getConnection(), defaultActionCallback, callbackHandler);
+                        else
+                            actionNotPlaying.execute(hostManager.getConnection(), defaultActionCallback, callbackHandler);
+                    }
+                }, buttonInAnim, buttonOutAnim));
+    }
+
 
     /**
      * Default callback for methods that don't return anything
@@ -385,6 +399,13 @@ public class RemoteFragment extends Fragment
         UIUtils.loadImageWithCharacterAvatar(getActivity(), hostManager,
                 thumbnailUrl, title,
                 thumbnail, thumbnail.getWidth(), thumbnail.getHeight());
+    }
+
+    /**
+     * Returns true if media is loaded (playing or paused)
+     */
+    private boolean isNowPlaying() {
+        return mediaPanel.getVisibility() == View.VISIBLE;
     }
 
     /**


### PR DESCRIPTION
This is what I have been using to allow the remote to trigger the context menu.  Without which it is difficult to do a few things such as queue a playlist.

This commit makes the codec button context sensitive so if media is loaded ( ```switchToPanel(R.id.media_panel)```) the codec button triggers, otherwise the context menu triggers (```switchToPanel(R.id.info_panel)```).

This is not ideal, as even though media is loaded/playing/paused and the media_panel might be loaded, the media could be in the background and you could be wandering around the menus wanting to trigger the context menu, forcing you to stop the media so that switchToPanel goes back to the info_panel to trigger the context menu.  Am unsure if you can ask kodi if the media is in the background? Also the bitmap would need to be also switched on the codec button which I have not done.

I probably never need a codec button and would have no issue if it were just a context button, but this seemed like a good compromise at the time.  Might be better to have it always a context menu button and hide the codec function away in a menu or something.

Anyhow noticed someone else reported an issue #19 about this so posting this in case useful, feel free to close or I can work on it further if required.
