### PR TITLE
update german translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -142,8 +142,8 @@
     <string name="back">Zurück</string>
 
     <string name="previous">Vorheriger</string>
-    <string name="next">Nächster</string>
-    <string name="finish">Beendet</string>
+    <string name="next">Weiter</string>
+    <string name="finish">Fertig</string>
     <string name="test_connection">Verbindungstest</string>
     <string name="search_again">Erneut Suchen</string>
 


### PR DESCRIPTION
maybe it would be good to split the contentDescription strings from the button caption strings. In German the next translation in the setup view isn't the same like next button on the remote.